### PR TITLE
Update and bugfix Shipwire Grabber

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-certifi==2017.11.5
+certifi==2019.9.11
 chardet==3.0.4
-idna==2.6
+idna==2.8
 iso8601==0.1.12
-pymongo==3.6.0
-pytz==2017.3
-requests==2.18.4
+pymongo==3.9.0
+pytz==2019.3
+requests==2.22.0
 shipwire==0.9.1
-urllib3==1.22
+urllib3==1.25.6

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -31,7 +31,7 @@ def get_orders(start_date, stop_date):
     return list(map(lambda item: item['resource'], res.all()))
 
 def get_stock():
-    res = shipwire.stock.products()
+    res = shipwire.stock.products(json=None)
     stock = list(map(lambda item: item['resource'], res.all()))
 
     for product in stock:

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -23,6 +23,7 @@ shipwire = Shipwire(
 
 def get_orders(start_date, stop_date):
     res = shipwire.orders.list(
+            json=None,
             completedAfter=start_date.astimezone(mst).isoformat(),
             completedBefore=stop_date.astimezone(mst).isoformat(),
             expand="items")


### PR DESCRIPTION
The shipwire grabber task failed last night. It was probably failing for a long while before that? Hooray Airflow for giving us new visibility into this!

After a very painful Pythonic debugging session, we discovered the cause of the problem. In the `shipwire` pip module we're using, the default json request body is a an empty string. Ref:
https://github.com/durbin/shipwire-python/blob/84e22a2f6277ea56b4c0e00219981ccbff93f517/shipwire/api.py#L95

That was sending a body of `""` (two quotes) with `GET` requests to the shipwire API. The API doesn't like, and returns a 400 `bad request`. Maybe the API has gotten stricter on this recently?

As a first pass to fix the bug, i've updated the `requirements.txt` with [`pur`](https://pypi.org/project/pur/). It didn't fix the problem, but since we're here. Let's update to latest and get rid of those security alerts.

CC @andyg0808 