### PR TITLE
Shipwire Grabber: Use date from environment

### DIFF
--- a/dates.py
+++ b/dates.py
@@ -8,11 +8,9 @@ def get_run_dates():
         raise RuntimeError("Expected variable {} in environment".format(RUN_DATE))
     today = datetime.date.fromisoformat(environ[RUN_DATE])
 
-    yesterday = datetime.datetime.combine(
-        today - datetime.timedelta(days=1), datetime.time.min
-    )
-    today = datetime.datetime.combine(
-        yesterday + datetime.timedelta(days=1), datetime.time.min
+    start_time = datetime.datetime.combine(today, datetime.time.min)
+    end_time = datetime.datetime.combine(
+        start_time + datetime.timedelta(days=1), datetime.time.min
     )
 
-    return (yesterday, today)
+    return (start_time, end_time)

--- a/dates.py
+++ b/dates.py
@@ -2,17 +2,11 @@ RUN_DATE = "RUN_FOR_DATE"
 import datetime
 from os import environ
 
-import pytz
-
 
 def get_run_dates():
-    mst = pytz.timezone("America/Phoenix")
-    now = datetime.datetime.now(tz=mst)
-
-    if RUN_DATE in environ:
-        today = datetime.date.fromisoformat(environ[RUN_DATE])
-    else:
-        today = now.date()
+    if RUN_DATE not in environ:
+        raise RuntimeError("Expected variable {} in environment".format(RUN_DATE))
+    today = datetime.date.fromisoformat(environ[RUN_DATE])
 
     yesterday = datetime.datetime.combine(
         today - datetime.timedelta(days=1), datetime.time.min
@@ -20,4 +14,5 @@ def get_run_dates():
     today = datetime.datetime.combine(
         yesterday + datetime.timedelta(days=1), datetime.time.min
     )
+
     return (yesterday, today)

--- a/dates.py
+++ b/dates.py
@@ -1,0 +1,23 @@
+RUN_DATE = "RUN_FOR_DATE"
+import datetime
+from os import environ
+
+import pytz
+
+
+def get_run_dates():
+    mst = pytz.timezone("America/Phoenix")
+    now = datetime.datetime.now(tz=mst)
+
+    if RUN_DATE in environ:
+        today = datetime.date.fromisoformat(environ[RUN_DATE])
+    else:
+        today = now.date()
+
+    yesterday = datetime.datetime.combine(
+        today - datetime.timedelta(days=1), datetime.time.min
+    )
+    today = datetime.datetime.combine(
+        yesterday + datetime.timedelta(days=1), datetime.time.min
+    )
+    return (yesterday, today)

--- a/dates_test.py
+++ b/dates_test.py
@@ -15,8 +15,8 @@ def test_missing_var(monkeypatch):
 def test_resolve(monkeypatch):
     monkeypatch.setenv("RUN_FOR_DATE", "2020-07-08")
 
-    yesterday, today = dates.get_run_dates()
-    assert today == datetime(2020, 7, 8, 0, 0, 0)
-    assert yesterday == datetime(2020, 7, 7, 0, 0, 0)
-    assert today.utcoffset() == None
-    assert yesterday.utcoffset() == None
+    start, end = dates.get_run_dates()
+    assert start == datetime(2020, 7, 8, 0, 0, 0)
+    assert end == datetime(2020, 7, 9, 0, 0, 0)
+    assert start.utcoffset() == None
+    assert end.utcoffset() == None

--- a/dates_test.py
+++ b/dates_test.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+import dates
+
+
+def test_missing_var(monkeypatch):
+    monkeypatch.delenv("RUN_FOR_DATE", raising=False)
+
+    with pytest.raises(RuntimeError, match=r"RUN_FOR_DATE"):
+        dates.get_run_dates()
+
+
+def test_resolve(monkeypatch):
+    monkeypatch.setenv("RUN_FOR_DATE", "2020-07-08")
+
+    yesterday, today = dates.get_run_dates()
+    assert today == datetime(2020, 7, 8, 0, 0, 0)
+    assert yesterday == datetime(2020, 7, 7, 0, 0, 0)
+    assert today.utcoffset() == None
+    assert yesterday.utcoffset() == None

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -13,38 +13,43 @@ mst = pytz.timezone("America/Phoenix")
 
 yesterday, today = get_run_dates()
 
-mongo = MongoClient(os.environ['MONGODB_URI'])
+mongo = MongoClient(os.environ["MONGODB_URI"])
 shipwire = Shipwire(
-            os.environ['SHIPWIRE_USER'],
-            os.environ['SHIPWIRE_PASSWORD'],
-            host='api.shipwire.com',
-            raise_on_errors=True)
+    os.environ["SHIPWIRE_USER"],
+    os.environ["SHIPWIRE_PASSWORD"],
+    host="api.shipwire.com",
+    raise_on_errors=True,
+)
+
 
 def get_orders(start_date, stop_date):
     res = shipwire.orders.list(
-            json=None,
-            completedAfter=start_date.astimezone(mst).isoformat(),
-            completedBefore=stop_date.astimezone(mst).isoformat(),
-            expand="items")
+        json=None,
+        completedAfter=start_date.astimezone(mst).isoformat(),
+        completedBefore=stop_date.astimezone(mst).isoformat(),
+        expand="items",
+    )
 
-    return list(map(lambda item: item['resource'], res.all()))
+    return list(map(lambda item: item["resource"], res.all()))
+
 
 def get_stock():
     res = shipwire.stock.products(json=None)
-    stock = list(map(lambda item: item['resource'], res.all()))
+    stock = list(map(lambda item: item["resource"], res.all()))
 
     for product in stock:
-        product['date'] = yesterday
+        product["date"] = yesterday
 
     return stock
+
 
 def clean_order(order):
     def clean_tree(doc):
         """Takes a document and recursively flattens "resource" objects"""
-        if 'resource' in doc:
-            return clean_tree(doc['resource'])
+        if "resource" in doc:
+            return clean_tree(doc["resource"])
 
-        if 'resourceLocation' in doc:
+        if "resourceLocation" in doc:
             return None
 
         if type(doc) is dict:
@@ -58,15 +63,16 @@ def clean_order(order):
 
     def convert_dates(doc):
         """Converts ISO8601 time strings to Datetime objects for MongoDB"""
-        for date in doc['events']:
-            doc['events'][date] = iso8601.parse_date(doc['events'][date])
+        for date in doc["events"]:
+            doc["events"][date] = iso8601.parse_date(doc["events"][date])
 
-        doc['lastUpdatedDate'] = iso8601.parse_date(doc['lastUpdatedDate'])
-        doc['processAfterDate'] = iso8601.parse_date(doc['processAfterDate'])
+        doc["lastUpdatedDate"] = iso8601.parse_date(doc["lastUpdatedDate"])
+        doc["processAfterDate"] = iso8601.parse_date(doc["processAfterDate"])
 
         return doc
 
     return convert_dates(clean_tree(order))
+
 
 orders_collection = mongo.warehouse.shipwire_orders
 stock_collection = mongo.warehouse.shipwire_stock

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -19,7 +19,8 @@ mongo = MongoClient(os.environ['MONGODB_URI'])
 shipwire = Shipwire(
             os.environ['SHIPWIRE_USER'],
             os.environ['SHIPWIRE_PASSWORD'],
-            host='api.shipwire.com')
+            host='api.shipwire.com',
+            raise_on_errors=True)
 
 def get_orders(start_date, stop_date):
     res = shipwire.orders.list(

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -7,11 +7,18 @@ import json
 
 from shipwire import Shipwire
 from pymongo import MongoClient
+from os import environ
+
+RUN_DATE = "RUN_FOR_DATE"
 
 mst = pytz.timezone("America/Phoenix")
 now = datetime.datetime.now(tz=mst)
 
-today = now.date()
+if RUN_DATE in environ:
+    today = datetime.date.fromisoformat(environ[RUN_DATE])
+else:
+    today = now.date()
+
 yesterday = datetime.datetime.combine(today - datetime.timedelta(days=1), datetime.time.min)
 today = datetime.datetime.combine(yesterday + datetime.timedelta(days=1), datetime.time.min)
 

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -1,26 +1,17 @@
 #!/usr/bin/env python3
-import os
-import datetime
-import pytz
-import iso8601
 import json
+import os
 
-from shipwire import Shipwire
+import iso8601
+import pytz
 from pymongo import MongoClient
-from os import environ
+from shipwire import Shipwire
 
-RUN_DATE = "RUN_FOR_DATE"
+from dates import get_run_dates
 
 mst = pytz.timezone("America/Phoenix")
-now = datetime.datetime.now(tz=mst)
 
-if RUN_DATE in environ:
-    today = datetime.date.fromisoformat(environ[RUN_DATE])
-else:
-    today = now.date()
-
-yesterday = datetime.datetime.combine(today - datetime.timedelta(days=1), datetime.time.min)
-today = datetime.datetime.combine(yesterday + datetime.timedelta(days=1), datetime.time.min)
+yesterday, today = get_run_dates()
 
 mongo = MongoClient(os.environ['MONGODB_URI'])
 shipwire = Shipwire(

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 pip install pipenv
 pipenv install
 pipenv run black --check .


### PR DESCRIPTION
Rather than using today's date all the time, let's fetch the date to update for from the environment. This allows us to easily run backfills from Airflow by passing the run date to the grabber script in the environment.

QA
---
I'll handle QA on this.