### PR TITLE
Bugfix  use correct date for stock numbers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-docker build -t "shipwire-analytics-grabber:${TAG:-latest}" .
+docker build -t "shipwire-analytics-grabber:${TAG:-testing}" .

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker build -t "shipwire-analytics-grabber:${TAG:-latest}" .

--- a/dates.py
+++ b/dates.py
@@ -1,6 +1,9 @@
 RUN_DATE = "RUN_FOR_DATE"
 import datetime
 from os import environ
+import pytz
+
+mst = pytz.timezone("America/Phoenix")
 
 
 def get_run_dates():
@@ -14,3 +17,11 @@ def get_run_dates():
     )
 
     return (start_time, end_time)
+
+
+def get_yesterday():
+    now = datetime.datetime.now(tz=mst)
+    today = now.date()
+    return datetime.datetime.combine(
+        today - datetime.timedelta(days=1), datetime.time.min
+    )

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+docker run \
+ --env RUN_FOR_DATE="$RUN_FOR_DATE" \
+ --env-file .env \
+ -v /etc/hosts:/etc/hosts \
+ $@ \
+ shipwire-analytics-grabber:"$TAG"

--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,4 @@ docker run \
  --env-file .env \
  -v /etc/hosts:/etc/hosts \
  $@ \
- shipwire-analytics-grabber:"$TAG"
+ shipwire-analytics-grabber:"${TAG:-testing}"

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -7,7 +7,13 @@ import pytz
 from pymongo import MongoClient
 from shipwire import Shipwire
 
+import logging
+
 from dates import get_run_dates
+
+logging.basicConfig()
+log = logging.getLogger("Shipwire Grabber")
+log.setLevel(logging.INFO)
 
 mst = pytz.timezone("America/Phoenix")
 
@@ -77,8 +83,12 @@ def clean_order(order):
 orders_collection = mongo.warehouse.shipwire_orders
 stock_collection = mongo.warehouse.shipwire_stock
 
-for order in get_orders(yesterday, today):
+orders = get_orders(yesterday, today)
+log.info("Found %d orders", len(orders))
+for order in orders:
     orders_collection.save(clean_order(order))
 
-for stock in get_stock():
+stocks = get_stock()
+log.info("Found %d stock values", len(stocks))
+for stock in stocks:
     stock_collection.save(stock)

--- a/shipwire-grabber.py
+++ b/shipwire-grabber.py
@@ -17,7 +17,7 @@ log.setLevel(logging.INFO)
 
 mst = pytz.timezone("America/Phoenix")
 
-yesterday, today = get_run_dates()
+start_time, end_time = get_run_dates()
 
 mongo = MongoClient(os.environ["MONGODB_URI"])
 shipwire = Shipwire(
@@ -83,7 +83,7 @@ def clean_order(order):
 orders_collection = mongo.warehouse.shipwire_orders
 stock_collection = mongo.warehouse.shipwire_stock
 
-orders = get_orders(yesterday, today)
+orders = get_orders(start_time, end_time)
 log.info("Found %d orders", len(orders))
 for order in orders:
     orders_collection.save(clean_order(order))

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 pip install pipenv
 pipenv install


### PR DESCRIPTION
This was accidentally inserting current data for whatever date was being backfilled. Now it always puts yesterday's date on the stock information. This is sorta correct, but could result in weird data if run during the middle of a day. So we also check if the date being run for is yesterday, which should mostly happen when running scheduled runs. There is a risk that rerunning this could result in odd values being inserted, but I don't think it's worth more effort right now.

There's a few tooling improvements and a bit of logging in here as well. They should have gone in the original PR that made this bug, but I missed them.